### PR TITLE
Used io.eventuate.common.quarkus.jdbc.test.configuration.TestProfileR…

### DIFF
--- a/eventuate-tram-quarkus-commands/src/main/java/io/eventuate/tram/quarkus/commands/CommandDispatcherInitializer.java
+++ b/eventuate-tram-quarkus-commands/src/main/java/io/eventuate/tram/quarkus/commands/CommandDispatcherInitializer.java
@@ -8,8 +8,10 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.PostConstruct;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 @Startup
+@Singleton
 public class CommandDispatcherInitializer {
   private Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/eventuate-tram-quarkus-commands/src/main/java/io/eventuate/tram/quarkus/commands/consumer/TramCommandConsumerConfiguration.java
+++ b/eventuate-tram-quarkus-commands/src/main/java/io/eventuate/tram/quarkus/commands/consumer/TramCommandConsumerConfiguration.java
@@ -4,12 +4,14 @@ import io.eventuate.tram.commands.consumer.CommandDispatcherFactory;
 import io.eventuate.tram.messaging.consumer.MessageConsumer;
 import io.eventuate.tram.messaging.producer.MessageProducer;
 
+import javax.enterprise.inject.Instance;
 import javax.inject.Singleton;
 
 @Singleton
 public class TramCommandConsumerConfiguration {
   @Singleton
-  public CommandDispatcherFactory commandDispatcherFactory(MessageConsumer messageConsumer, MessageProducer messageProducer) {
-    return new CommandDispatcherFactory(messageConsumer, messageProducer);
+  public CommandDispatcherFactory commandDispatcherFactory(Instance<MessageConsumer> messageConsumer,
+                                                           Instance<MessageProducer> messageProducer) {
+    return new CommandDispatcherFactory(messageConsumer.get(), messageProducer.get());
   }
 }

--- a/eventuate-tram-quarkus-commands/src/main/java/io/eventuate/tram/quarkus/commands/producer/TramCommandProducerConfiguration.java
+++ b/eventuate-tram-quarkus-commands/src/main/java/io/eventuate/tram/quarkus/commands/producer/TramCommandProducerConfiguration.java
@@ -4,12 +4,13 @@ import io.eventuate.tram.commands.producer.CommandProducer;
 import io.eventuate.tram.commands.producer.CommandProducerImpl;
 import io.eventuate.tram.messaging.producer.MessageProducer;
 
+import javax.enterprise.inject.Instance;
 import javax.inject.Singleton;
 
 @Singleton
 public class TramCommandProducerConfiguration {
   @Singleton
-  public CommandProducer commandProducer(MessageProducer messageProducer) {
-    return new CommandProducerImpl(messageProducer);
+  public CommandProducer commandProducer(Instance<MessageProducer> messageProducer) {
+    return new CommandProducerImpl(messageProducer.get());
   }
 }

--- a/eventuate-tram-quarkus-consumer-jdbc/build.gradle
+++ b/eventuate-tram-quarkus-consumer-jdbc/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
 plugins {
     id "io.quarkus" version "${quarkusVersion}"
     id 'org.kordamp.gradle.jandex' version '0.6.0'
@@ -17,4 +19,9 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+processTestResources {
+    outputs.upToDateWhen { false }
+    filter ReplaceTokens, tokens: ["EVENTUATEDATABASE": System.env.EVENTUATEDATABASE ?: "mysql"]
 }

--- a/eventuate-tram-quarkus-consumer-jdbc/src/test/java/io/eventuate/tram/quarkus/consumer/jdbc/EventuateQuarkusSqlTableBasedDuplicateMessageDetectorTest.java
+++ b/eventuate-tram-quarkus-consumer-jdbc/src/test/java/io/eventuate/tram/quarkus/consumer/jdbc/EventuateQuarkusSqlTableBasedDuplicateMessageDetectorTest.java
@@ -1,7 +1,9 @@
 package io.eventuate.tram.quarkus.consumer.jdbc;
 
+import io.eventuate.common.quarkus.jdbc.test.configuration.TestProfileResolver;
 import io.eventuate.tram.consumer.common.DuplicateMessageDetector;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
@@ -10,6 +12,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @QuarkusTest
+@TestProfile(TestProfileResolver.class)
 public class EventuateQuarkusSqlTableBasedDuplicateMessageDetectorTest {
 
   @Inject

--- a/eventuate-tram-quarkus-consumer-jdbc/src/test/resources/application.properties
+++ b/eventuate-tram-quarkus-consumer-jdbc/src/test/resources/application.properties
@@ -1,0 +1,13 @@
+quarkus.datasource.username=mysqluser
+quarkus.datasource.password=mysqlpw
+quarkus.datasource.jdbc.url=jdbc:mysql://localhost/eventuate
+
+%postgresql.quarkus.datasource.username=eventuate
+%postgresql.quarkus.datasource.password=eventuate
+%postgresql.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/eventuate
+
+%mssql.quarkus.datasource.username=sa
+%mssql.quarkus.datasource.password=Eventuate123!
+%mssql.quarkus.datasource.jdbc.url=jdbc:sqlserver://localhost:1433;databaseName=eventuate
+
+quarkus.datasource.db-kind=@EVENTUATEDATABASE@

--- a/eventuate-tram-quarkus-events/src/main/java/io/eventuate/tram/quarkus/events/publisher/TramEventsPublisherConfiguration.java
+++ b/eventuate-tram-quarkus-events/src/main/java/io/eventuate/tram/quarkus/events/publisher/TramEventsPublisherConfiguration.java
@@ -5,13 +5,15 @@ import io.eventuate.tram.events.publisher.DomainEventPublisher;
 import io.eventuate.tram.events.publisher.DomainEventPublisherImpl;
 import io.eventuate.tram.messaging.producer.MessageProducer;
 
+import javax.enterprise.inject.Instance;
 import javax.inject.Singleton;
 
 @Singleton
 public class TramEventsPublisherConfiguration {
 
   @Singleton
-  public DomainEventPublisher domainEventPublisher(MessageProducer messageProducer, DomainEventNameMapping domainEventNameMapping) {
-    return new DomainEventPublisherImpl(messageProducer, domainEventNameMapping);
+  public DomainEventPublisher domainEventPublisher(Instance<MessageProducer> messageProducer,
+                                                   Instance<DomainEventNameMapping> domainEventNameMapping) {
+    return new DomainEventPublisherImpl(messageProducer.get(), domainEventNameMapping.get());
   }
 }

--- a/eventuate-tram-quarkus-events/src/main/java/io/eventuate/tram/quarkus/events/subscriber/DomainEventDispatcherInitializer.java
+++ b/eventuate-tram-quarkus-events/src/main/java/io/eventuate/tram/quarkus/events/subscriber/DomainEventDispatcherInitializer.java
@@ -8,8 +8,10 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.PostConstruct;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 @Startup
+@Singleton
 public class DomainEventDispatcherInitializer {
   private Logger logger = LoggerFactory.getLogger(getClass());
 


### PR DESCRIPTION
…esolver in EventuateQuarkusSqlTableBasedDuplicateMessageDetectorTest.  Added missed Singleton annotations to Startup beans (Those use Postconstruct). Used Instance injection for not resolvable at build time beans.